### PR TITLE
#6 - AuditingFields 추출

### DIFF
--- a/.idea/workspace.xml
+++ b/.idea/workspace.xml
@@ -125,7 +125,7 @@
       <recent name="com.board.board.repository" />
     </key>
   </component>
-  <component name="RunManager" selected="Spring Boot.BoardApplication">
+  <component name="RunManager" selected="JUnit.JpaRepositoryTest.givenTestData_whenDeleting_thenWorksFine">
     <configuration name="BoardApplicationTests" type="JUnit" factoryName="JUnit" temporary="true" nameIsGenerated="true">
       <module name="board.test" />
       <extension name="coverage">
@@ -240,7 +240,7 @@
       <option name="presentableId" value="Default" />
       <updated>1741002624975</updated>
       <workItem from="1741002626343" duration="554000" />
-      <workItem from="1741013306456" duration="22871000" />
+      <workItem from="1741013306456" duration="23652000" />
     </task>
     <servers />
   </component>

--- a/board/src/main/java/com/board/board/domain/Article.java
+++ b/board/src/main/java/com/board/board/domain/Article.java
@@ -25,9 +25,8 @@ import java.util.Set;
         @Index(columnList = "createdBy")
 
 })
-@EntityListeners(AuditingEntityListener.class)
 @Entity
-public class Article {
+public class Article extends AuditingFields {
 
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
@@ -44,16 +43,6 @@ public class Article {
     @OrderBy("id")
     @OneToMany(mappedBy = "article", cascade = CascadeType.ALL)
     private final Set<ArticleComment> articleComments = new LinkedHashSet<>();
-
-
-
-
-    // 메타 데이터
-    @CreatedDate @Column(nullable = false) private LocalDateTime createdAt; // 생성일시
-    @CreatedBy @Column(nullable = false, length = 100) private String createdBy; // 생성자
-    @LastModifiedDate @Column(nullable = false) private LocalDateTime modifiedAt; // 수정일시
-    @LastModifiedBy @Column(nullable = false, length = 100) private String modifiedBy; // 수정자
-
 
     protected Article() {
     }

--- a/board/src/main/java/com/board/board/domain/ArticleComment.java
+++ b/board/src/main/java/com/board/board/domain/ArticleComment.java
@@ -21,9 +21,8 @@ import java.util.Objects;
         @Index(columnList = "createdBy")
 
 })
-@EntityListeners(AuditingEntityListener.class)
 @Entity
-public class ArticleComment {
+public class ArticleComment extends AuditingFields {
 
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
@@ -32,11 +31,6 @@ public class ArticleComment {
     @Setter @ManyToOne(optional = false) private Article article; // 게시글 (ID)
     @Setter @Column(nullable = false) private String content; // 내용
 
-    // 메타 데이터
-    @CreatedDate @Column(nullable = false) private LocalDateTime createdAt; // 생성일시
-    @CreatedBy @Column(nullable = false, length = 100) private String createdBy; // 생성자
-    @LastModifiedDate @Column(nullable = false) private LocalDateTime modifiedAt; // 수정일시
-    @LastModifiedBy @Column(nullable = false, length = 100) private String modifiedBy; // 수정자
 
     protected ArticleComment() {}
 

--- a/board/src/main/java/com/board/board/domain/AuditingFields.java
+++ b/board/src/main/java/com/board/board/domain/AuditingFields.java
@@ -1,0 +1,42 @@
+package com.board.board.domain;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.EntityListeners;
+import jakarta.persistence.MappedSuperclass;
+import lombok.Getter;
+import lombok.ToString;
+import org.springframework.data.annotation.CreatedBy;
+import org.springframework.data.annotation.CreatedDate;
+import org.springframework.data.annotation.LastModifiedBy;
+import org.springframework.data.annotation.LastModifiedDate;
+import org.springframework.data.jpa.domain.support.AuditingEntityListener;
+import org.springframework.format.annotation.DateTimeFormat;
+
+import java.time.LocalDateTime;
+
+@Getter
+@ToString
+@EntityListeners(AuditingEntityListener.class)
+@MappedSuperclass
+public class AuditingFields {
+
+    // 메타 데이터
+    @DateTimeFormat(iso = DateTimeFormat.ISO.DATE_TIME)
+    @CreatedDate
+    @Column(nullable = false)
+    private LocalDateTime createdAt; // 생성일시
+
+    @CreatedBy
+    @Column(nullable = false, length = 100)
+    private String createdBy; // 생성자
+
+    @DateTimeFormat(iso = DateTimeFormat.ISO.DATE_TIME)
+    @LastModifiedDate
+    @Column(nullable = false)
+    private LocalDateTime modifiedAt; // 수정일시
+
+    @LastModifiedBy
+    @Column(nullable = false, length = 100)
+    private String modifiedBy; // 수정자
+
+}


### PR DESCRIPTION
생성자, 생성일시, 수정자, 수정일시는 반복적으로
엔티티 클래스에 들어가는 요소이고,
도메인과 직접 연관이 없는 요소이므로
추출이 가능하다

`@MappedSuperclass` 이용하여 상속 방식으로 추출함

그외 `@DateTimeFormat` 요소 추가 및 jpa 옵션 개선